### PR TITLE
feat: Adding a docker environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=mysecretpassword
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=admin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,23 +1,35 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Launch built-in server and debug",
-            "type": "php",
-            "request": "launch",
-            "runtimeArgs": [
-                "-S",
-                "localhost:8000",
-                "-t",
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Listen for Xdebug",
+			"type": "php",
+			"request": "launch",
+			"port": [
+				9003
+			],
+			"pathMappings": {
+			"/var/www/src": "${workspaceFolder}\\src",
+			"/var/www/html": "${workspaceFolder}\\public",
+			}
+		},
+		{
+			"name": "Launch built-in server and debug",
+			"type": "php",
+			"request": "launch",
+			"runtimeArgs": [
+				"-S",
+				"localhost:8000",
+				"-t",
                 "public"
-            ],
-            "port": 9003,
-            "serverReadyAction": {
-                "action": "openExternally"
-            }
-        },
-    ]
+			],
+			"port": 9003,
+			"serverReadyAction": {
+				"action": "openExternally"
+			}
+		},
+	]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:8.3.11-fpm
+RUN pecl install xdebug-3.3.2
+RUN docker-php-ext-enable xdebug

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,21 @@
+server {
+    index index.php index.html;
+    server_name phpfpm.local;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/html;
+	location / {
+        # Try to serve static files directly, if they don't exist route to index.php
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+    location ~ \.php$ {
+        # try_files $uri =404;
+        # fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php-fpm:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+		fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+    }
+}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,37 @@
+services:
+  web:
+    image: nginx:1.27.1
+    ports:
+      - '8080:80'
+    volumes:
+      - ./public:/var/www/html
+      - ./default.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - internal
+
+  php-fpm:
+    image: php:8.3.11-fpm
+    volumes:
+      - ./src:/var/www/src
+      - ./public:/var/www/html 
+    networks:
+      - internal
+    environment:
+      XDEBUG_MODE: debug
+      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003
+  postgresql:
+    image: postgres:16.4
+    environment:
+      POSTGRES_DB: db_looper
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./.pgdata:/var/lib/postgresql/data
+    networks:
+      - internal
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  web:
+    image: nginx:1.27.1
+    ports:
+      - '8080:80'
+    volumes:
+      - ./public:/var/www/html
+      - ./default.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - internal
+
+  php-fpm:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./src:/var/www/src
+      - ./public:/var/www/html 
+    networks:
+      - internal
+    environment:
+      XDEBUG_MODE: debug
+      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003
+  postgresql:
+    image: postgres:16.4
+    environment:
+      POSTGRES_DB: db_looper
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./.pgdata:/var/lib/postgresql/data
+    networks:
+      - internal
+
+  pgadmin4:
+    image: elestio/pgadmin:REL-8_11
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_LISTEN_PORT: 8080
+    ports:
+      - "8081:8080"
+    networks:
+      - internal
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
there is 2 env, one including debug tools, and one ready for production

I also added a launch configuration for vscode to listen to the xdebug in the dev environment

To run debug version :
`docker compose up`

To run prod version :
`docker compose -f .\docker-compose-prod.yml up`

To remove the docker enviroment :
`docker compose down`
or
`docker compose -f .\docker-compose-prod.yml down`